### PR TITLE
Completes Task 18

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -502,17 +502,111 @@ describe("/api/articles/:article_id/comments", () => {
   });
 });
 
-describe("DELETE /api/comments/:comment_id", () => {
-  test("204: Responds with a 204 status code and no content when deleting a comment", () => {
-    return request(app).delete("/api/comments/1").expect(204);
+describe("/api/comments/:comment_id", () => {
+  describe("DELETE", () => {
+    test("204: Responds with a 204 status code and no content when deleting a comment", () => {
+      return request(app).delete("/api/comments/1").expect(204);
+    });
+
+    test("404: Responds with a comment not found error when trying to delete a comment that doesn't exist", () => {
+      return request(app).delete("/api/comments/999").expect(404);
+    });
+
+    test("400: Responds with a bad request error when trying to delete an invalid comment", () => {
+      return request(app).delete("/api/comments/not-a-comment_id").expect(400);
+    });
   });
 
-  test("404: Responds with a comment not found error when trying to delete a comment that doesn't exist", () => {
-    return request(app).delete("/api/comments/999").expect(404);
+  describe("PATCH", () => {
+    test("200: Responds with the updated comment with added votes", () => {
+      const newVotes = {
+        inc_votes: 10,
+      };
+
+      return request(app)
+        .patch("/api/comments/1")
+        .send(newVotes)
+        .expect(200)
+        .then(({ body }) => {
+          const { comment } = body;
+          expect(comment.votes).toBe(26);
+        });
+    });
+
+    test("200: Responds with the updated comment with added negative votes", () => {
+      const newVotes = {
+        inc_votes: -10,
+      };
+
+      return request(app)
+        .patch("/api/comments/1")
+        .send(newVotes)
+        .expect(200)
+        .then(({ body }) => {
+          const { comment } = body;
+          expect(comment.votes).toBe(6);
+        });
+    });
   });
 
-  test("400: Responds with a bad request error when trying to delete an invalid comment", () => {
-    return request(app).delete("/api/comments/not-a-comment_id").expect(400);
+  test("404: Responds with a comment not found error when trying to update a comment that doesn't exist", () => {
+    const newVotes = {
+      inc_votes: 10,
+    };
+
+    return request(app)
+      .patch("/api/comments/9999")
+      .send(newVotes)
+      .expect(404)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("comment not found");
+      });
+  });
+
+  test("400: Responds with a bad request error when trying to update an invalid comment", () => {
+    const newVotes = {
+      inc_votes: 10,
+    };
+
+    return request(app)
+      .patch("/api/comments/not-an-article")
+      .send(newVotes)
+      .expect(400)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("bad request");
+      });
+  });
+
+  test("400: Responds with a bad request error when trying to update a comment with invalid data", () => {
+    const newVotes = {
+      inc_votes: "Not-a-number",
+    };
+
+    return request(app)
+      .patch("/api/comments/1")
+      .send(newVotes)
+      .expect(400)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("bad request");
+      });
+  });
+
+  test("400: Responds with a bad request error when trying to update a comment with incorrectly named data", () => {
+    const newVotes = {
+      not_votes: 10,
+    };
+
+    return request(app)
+      .patch("/api/comments/1")
+      .send(newVotes)
+      .expect(400)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("bad request");
+      });
   });
 });
 

--- a/controllers/app.controller.js
+++ b/controllers/app.controller.js
@@ -67,7 +67,7 @@ exports.postComment = (req, res, next) => {
 };
 
 exports.incrementArticleVotes = (req, res, next) => {
-  const { article_id } = req.params;
+  const article_id = req.params;
   const { inc_votes } = req.body;
   patchVotes(article_id, inc_votes)
     .then((article) => {
@@ -98,6 +98,16 @@ exports.getUserById = (req, res, next) => {
   fetchUserById(username)
     .then((user) => {
       res.status(200).send({ user });
+    })
+    .catch(next);
+};
+
+exports.incrementCommentVotes = (req, res, next) => {
+  const comment_id = req.params;
+  const { inc_votes } = req.body;
+  patchVotes(comment_id, inc_votes)
+    .then((comment) => {
+      res.status(200).send({ comment });
     })
     .catch(next);
 };

--- a/models/app.model.js
+++ b/models/app.model.js
@@ -110,23 +110,23 @@ exports.pushComment = (article_id, username, body) => {
     });
 };
 
-exports.patchVotes = (article_id, inc_votes) => {
-  return db
-    .query(
-      `
-    UPDATE articles
-    SET votes = votes + $1
-    WHERE article_id = $2
-    RETURNING *;
-    `,
-      [inc_votes, article_id]
-    )
-    .then(({ rows }) => {
-      if (rows.length === 0) {
-        return Promise.reject({ status: 404, msg: "article not found" });
-      }
-      return rows[0];
-    });
+exports.patchVotes = (id, inc_votes) => {
+  const [source] = Object.keys(id);
+  const newSource = source.slice(0, -3);
+  const sqlQuery =
+    `UPDATE ` +
+    newSource +
+    "s" +
+    ` SET votes = votes + $1 WHERE ` +
+    source +
+    ` = $2 RETURNING *;`;
+  const queryValues = [inc_votes, id[source]];
+  return db.query(sqlQuery, queryValues).then(({ rows }) => {
+    if (rows.length === 0) {
+      return Promise.reject({ status: 404, msg: `${newSource} not found` });
+    }
+    return rows[0];
+  });
 };
 
 exports.removeComment = (comment_id) => {

--- a/routes/comments.router.js
+++ b/routes/comments.router.js
@@ -1,7 +1,13 @@
 const commentsRouter = require("express").Router();
 
-const { deleteComment } = require("../controllers/app.controller");
+const {
+  deleteComment,
+  incrementCommentVotes,
+} = require("../controllers/app.controller");
 
-commentsRouter.delete("/:comment_id", deleteComment);
+commentsRouter
+  .route("/:comment_id")
+  .delete(deleteComment)
+  .patch(incrementCommentVotes);
 
 module.exports = commentsRouter;


### PR DESCRIPTION
Decided to make the already existing patchVotes function (for articles) dynamic, instead of creating a new one for comments, it should avoid SQL injection as the key of id can only ever be 'comment_id' or 'article_id' due to the router path ('comments/:comment_id').